### PR TITLE
Remove dangling Drupot features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/trevorjohnleake/magenpot
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/Pallinder/go-randomdata v1.1.0
+	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/d1str0/hpfeeds v0.1.3
-	github.com/google/uuid v1.1.0
+	github.com/google/uuid v1.1.1
 	github.com/threatstream/agave v0.1.2
 	golang.org/x/text v0.3.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,13 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Pallinder/go-randomdata v1.1.0 h1:gUubB1IEUliFmzjqjhf+bgkg1o6uoFIkRsP3VrhEcx8=
-github.com/Pallinder/go-randomdata v1.1.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
+github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00lCDlaYPg=
+github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/d1str0/hpfeeds v0.1.3 h1:Q/ne7McgijzF2FsbCY/yy5WDLWMph2E39Am6LlI91WI=
 github.com/d1str0/hpfeeds v0.1.3/go.mod h1:Vz6oY+o+BF++pu8d/Aj9fjeVWMTGQjOIi2Ow/2+kLSY=
-github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
-github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/threatstream/agave v0.1.2 h1:PGwtArtBFZq5G8QVJ6Ip0ueyd3iNZwj/AqFj52NUVCE=
 github.com/threatstream/agave v0.1.2/go.mod h1:lgZMTytrct22p7zBqsydz8YH1mCbWsaoOb/t1LaPTKs=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/routes.go
+++ b/routes.go
@@ -11,7 +11,6 @@ import (
 
 var templates = template.Must(template.ParseGlob("templates/*"))
 
-const CVE20196340 = "CVE-2019-6340" // What is this?
 const MagentoScan = "Magento Scanner"
 const MagentoScanLogin = "Magento Scanner - Login Page"
 const MagentoScanAdminLogin = "Magento Scanner - Admin Login Page"


### PR DESCRIPTION
Err422, getHost(), NotFoundHandler(), CVE2019 const, etc are not needed for Magento.